### PR TITLE
sensu-go v5.0.0 release compatibility

### DIFF
--- a/library/sensu_go_check.py
+++ b/library/sensu_go_check.py
@@ -138,7 +138,7 @@ def run_module():
     sensuctl = Sensuctl(module)
     # Fetch the existing checks so we know what we're working with
     checks = sensuctl.checks_list(module)
-    check_names = [check['name'] for check in checks]
+    check_names = [check['metadata']['name'] for check in checks]
 
     if module.params['state'] == 'list':
         result['checks'] = checks


### PR DESCRIPTION
metadata dict was created to contain name, namespace in the
first stable release of sensu-go. move name reference to the
dict.

this fixes issue #21