### PR TITLE
Feature/add back ubuntu 14.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ The following Operating Systems are automatically tested:
 - [Amazon Linux 2](https://aws.amazon.com/amazon-linux-2/)
 - [CentOS - 6](https://wiki.centos.org/Manuals/ReleaseNotes/CentOS6.10)
 - [CentOS - 7](https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7)
+- [Ubuntu - 14.04 (Trusty Tahr)](http://releases.ubuntu.com/14.04/)
 - [Ubuntu - 16.04 (Xenial Xerus)](http://releases.ubuntu.com/16.04/)
 - [Ubuntu - 18.04 (Bionic Beaver)](http://releases.ubuntu.com/18.04/)
 
 The following Operating Systems are currently unsupported until Sensu Go
 packages are officially published for them:
-- [Ubuntu - 14.04 (Trusty Tahr)](http://releases.ubuntu.com/14.04/)
 - [Fedora - 26](https://docs.fedoraproject.org/en-US/fedora/f26/release-notes/)
 - [Fedora - 27](https://docs.fedoraproject.org/en-US/fedora/f27/release-notes/)
 - [Fedora - 28](https://docs.fedoraproject.org/en-US/fedora/f28/release-notes/)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,6 +6,10 @@ galaxy_info:
   min_ansible_version: 2.7
   github_branch: master
   platforms:
+    - name: Amazon
+      versions:
+        - Candidate
+        - 2017.12
     - name: EL
       versions:
         - 6

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
         - 7
     - name: Ubuntu
       versions:
+        - trusty
         - vivid
         - bionic
   galaxy_tags:

--- a/molecule/ubuntu/molecule.yml
+++ b/molecule/ubuntu/molecule.yml
@@ -8,6 +8,11 @@ driver:
 lint:
   name: yamllint
 platforms:
+  - name: ubuntu-14.04
+    image: dokken/ubuntu-14.04
+    command: /sbin/init
+    capabilities:
+      - SYS_ADMIN
   - name: ubuntu-16.04
     image: dokken/ubuntu-16.04
     command: /bin/systemd


### PR DESCRIPTION
Sensu Go 5.1.0 added support for Ubuntu 14.04, this PR adds it back to the fold of supported OS's. I also updated the meta file to officially list Amazon Linux as I missed that. 