### PR TITLE
Add Fedora Support back & drop docs override

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - env: SCENARIO=fedora  # Unsupported, no Sensu Go packages
     - env: SCENARIO=debian  # Unsupported, no Sensu Go packages
 
 services: docker

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ specifically test using the version of `Ansible` and `python` declared in the
 [Pipefile](https://github.com/jaredledvina/sensu-go-ansible/blob/master/Pipfile)
 
 The following Operating Systems are automatically tested:
+- [Fedora - 26](https://docs.fedoraproject.org/en-US/fedora/f26/release-notes/)
+- [Fedora - 27](https://docs.fedoraproject.org/en-US/fedora/f27/release-notes/)
+- [Fedora - 28](https://docs.fedoraproject.org/en-US/fedora/f28/release-notes/)
+- [Fedora - 29](https://docs.fedoraproject.org/en-US/fedora/f29/release-notes/)
 - [Amazon Linux](https://aws.amazon.com/amazon-linux-ami/)
 - [Amazon Linux 2](https://aws.amazon.com/amazon-linux-2/)
 - [CentOS - 6](https://wiki.centos.org/Manuals/ReleaseNotes/CentOS6.10)
@@ -98,10 +102,6 @@ The following Operating Systems are automatically tested:
 
 The following Operating Systems are currently unsupported until Sensu Go
 packages are officially published for them:
-- [Fedora - 26](https://docs.fedoraproject.org/en-US/fedora/f26/release-notes/)
-- [Fedora - 27](https://docs.fedoraproject.org/en-US/fedora/f27/release-notes/)
-- [Fedora - 28](https://docs.fedoraproject.org/en-US/fedora/f28/release-notes/)
-- [Fedora - 29](https://docs.fedoraproject.org/en-US/fedora/f29/release-notes/)
 - [Debian - 8 (Jessie)](https://wiki.debian.org/DebianJessie)
 - [Debian - 9 (Stretch)](https://wiki.debian.org/DebianStretch)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,6 +6,12 @@ galaxy_info:
   min_ansible_version: 2.7
   github_branch: master
   platforms:
+    - name: Fedora
+      versions:
+        - 26
+        - 27
+        - 28
+        - 29
     - name: Amazon
       versions:
         - Candidate

--- a/molecule/shared/prepare.yml
+++ b/molecule/shared/prepare.yml
@@ -1,18 +1,5 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: true
-  tasks:
-    - name: Enable yum doc files
-      lineinfile:
-        regexp: tsflags=nodocs
-        path: /etc/yum.conf
-        state: absent
-      when: ansible_pkg_mgr == 'yum'
-
-    - name: Enable apt doc files
-      lineinfile:
-        regexp: 'path-exclude=/usr/share/doc/*'
-        path: /etc/dpkg/dpkg.cfg.d/excludes
-        state: absent
-      when: ansible_pkg_mgr == 'apt'
+  gather_facts: false
+  tasks: []


### PR DESCRIPTION
From https://github.com/sensu/sensu-go-chef/pull/42#issuecomment-448378954, this might not be needed anymore.

Opening a PR to kick off tests to see if this works. 