### PR TITLE
Add back Debian support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
   - SCENARIO=centos
   - SCENARIO=fedora
   - SCENARIO=amazonlinux
-  - SCENARIO=debian
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ env:
   - SCENARIO=centos
   - SCENARIO=fedora
   - SCENARIO=amazonlinux
+  - SCENARIO=debian
+
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: SCENARIO=debian  # Unsupported, no Sensu Go packages
 
 services: docker
 addons:

--- a/README.md
+++ b/README.md
@@ -88,22 +88,19 @@ specifically test using the version of `Ansible` and `python` declared in the
 [Pipefile](https://github.com/jaredledvina/sensu-go-ansible/blob/master/Pipfile)
 
 The following Operating Systems are automatically tested:
-- [Fedora - 26](https://docs.fedoraproject.org/en-US/fedora/f26/release-notes/)
-- [Fedora - 27](https://docs.fedoraproject.org/en-US/fedora/f27/release-notes/)
-- [Fedora - 28](https://docs.fedoraproject.org/en-US/fedora/f28/release-notes/)
-- [Fedora - 29](https://docs.fedoraproject.org/en-US/fedora/f29/release-notes/)
 - [Amazon Linux](https://aws.amazon.com/amazon-linux-ami/)
 - [Amazon Linux 2](https://aws.amazon.com/amazon-linux-2/)
 - [CentOS - 6](https://wiki.centos.org/Manuals/ReleaseNotes/CentOS6.10)
 - [CentOS - 7](https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7)
+- [Debian - 8 (Jessie)](https://wiki.debian.org/DebianJessie)
+- [Debian - 9 (Stretch)](https://wiki.debian.org/DebianStretch)
+- [Fedora - 26](https://docs.fedoraproject.org/en-US/fedora/f26/release-notes/)
+- [Fedora - 27](https://docs.fedoraproject.org/en-US/fedora/f27/release-notes/)
+- [Fedora - 28](https://docs.fedoraproject.org/en-US/fedora/f28/release-notes/)
+- [Fedora - 29](https://docs.fedoraproject.org/en-US/fedora/f29/release-notes/)
 - [Ubuntu - 14.04 (Trusty Tahr)](http://releases.ubuntu.com/14.04/)
 - [Ubuntu - 16.04 (Xenial Xerus)](http://releases.ubuntu.com/16.04/)
 - [Ubuntu - 18.04 (Bionic Beaver)](http://releases.ubuntu.com/18.04/)
-
-The following Operating Systems are currently unsupported until Sensu Go
-packages are officially published for them:
-- [Debian - 8 (Jessie)](https://wiki.debian.org/DebianJessie)
-- [Debian - 9 (Stretch)](https://wiki.debian.org/DebianStretch)
 
 Caveats
 -------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,6 +25,10 @@ galaxy_info:
         - trusty
         - vivid
         - bionic
+    - name: Debian
+      versions:
+        - jessie
+        - stretch
   galaxy_tags:
     - sensu
     - sensugo


### PR DESCRIPTION
https://docs.sensu.io/sensu-go/5.2/release-notes/#5.2.0-changes

🎉 
> Sensu now includes support for Debian 8 and 9

🎉 

Signed-off-by: Jared Ledvina <jared@techsmix.net>