### PR TITLE
Repos - Rename prerelease to go for consistency

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -14,3 +14,7 @@
   service:
     name: sensu-agent
     state: restarted
+
+- name: update apt cache
+  apt:
+    update_cache: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -18,3 +18,8 @@
 - name: update apt cache
   apt:
     update_cache: true
+
+- name: yum-clean-metadata
+  command: yum clean metadata
+  args:
+    warn: no

--- a/molecule/shared/tests/test_default.rb
+++ b/molecule/shared/tests/test_default.rb
@@ -43,12 +43,12 @@ if os.redhat?
     it { should be_installed }
   end
 
-  describe yum.repo('sensu_prerelease') do
+  describe yum.repo('sensu_go') do
     it { should exist }
     it { should be_enabled }
   end
 
-  describe yum.repo('sensu_prerelease-source') do
+  describe yum.repo('sensu_go-source') do
     it { should exist }
     it { should be_enabled }
   end

--- a/tasks/repo/apt.yml
+++ b/tasks/repo/apt.yml
@@ -15,14 +15,14 @@
 
 - name: Configure Sensu Go apt repos
   apt_repository:
-    filename: sensu_prerelease
+    filename: sensu_go
     repo: "{{ sensu_go_final_repos[ansible_pkg_mgr]['deb'] }}"
     update_cache: true
   when: sensu_go_final_repos[ansible_pkg_mgr]['deb'] is defined
 
 - name: Configure Sensu Go apt source repos
   apt_repository:
-    filename: sensu_prerelease
+    filename: sensu_go-source
     repo: "{{ sensu_go_final_repos[ansible_pkg_mgr]['deb-src'] }}"
     update_cache: true
   when: sensu_go_final_repos[ansible_pkg_mgr]['deb-src'] is defined

--- a/tasks/repo/apt.yml
+++ b/tasks/repo/apt.yml
@@ -17,12 +17,28 @@
   apt_repository:
     filename: sensu_go
     repo: "{{ sensu_go_final_repos[ansible_pkg_mgr]['deb'] }}"
-    update_cache: true
+    update_cache: false
   when: sensu_go_final_repos[ansible_pkg_mgr]['deb'] is defined
+  notify: update apt cache
+
+- name: Cleanup - Remove old sensu_prerelease repo
+  apt_repository:
+    filename: sensu_prerelease
+    state: absent
+    update_cache: false
+  notify: update apt cache
 
 - name: Configure Sensu Go apt source repos
   apt_repository:
-    filename: sensu_go-source
+    filename: sensu_go
     repo: "{{ sensu_go_final_repos[ansible_pkg_mgr]['deb-src'] }}"
-    update_cache: true
+    update_cache: false
   when: sensu_go_final_repos[ansible_pkg_mgr]['deb-src'] is defined
+  notify: update apt cache
+
+- name: Cleanup - Remove old sensu_prerelease-source repo
+  apt_repository:
+    filename: sensu_prerelease-source
+    state: absent
+    update_cache: false
+  notify: update apt cache

--- a/tasks/repo/apt.yml
+++ b/tasks/repo/apt.yml
@@ -42,3 +42,6 @@
     state: absent
     update_cache: false
   notify: update apt cache
+
+- name: Flush handlers
+  meta: flush_handlers

--- a/tasks/repo/apt.yml
+++ b/tasks/repo/apt.yml
@@ -21,13 +21,6 @@
   when: sensu_go_final_repos[ansible_pkg_mgr]['deb'] is defined
   notify: update apt cache
 
-- name: Cleanup - Remove old sensu_prerelease repo
-  apt_repository:
-    filename: sensu_prerelease
-    state: absent
-    update_cache: false
-  notify: update apt cache
-
 - name: Configure Sensu Go apt source repos
   apt_repository:
     filename: sensu_go
@@ -36,11 +29,10 @@
   when: sensu_go_final_repos[ansible_pkg_mgr]['deb-src'] is defined
   notify: update apt cache
 
-- name: Cleanup - Remove old sensu_prerelease-source repo
-  apt_repository:
-    filename: sensu_prerelease-source
+- name: Cleanup - Remove old sensu_prerelease repo
+  file:
+    path: /etc/apt/sources.list.ld/sensu_prerelease
     state: absent
-    update_cache: false
   notify: update apt cache
 
 - name: Flush handlers

--- a/tasks/repo/dnf.yml
+++ b/tasks/repo/dnf.yml
@@ -16,8 +16,8 @@
 
 - name: Configure Sensu Go yum repos
   yum_repository:
-    file: sensu_prerelease
-    name: sensu_prerelease
+    file: sensu_go
+    name: sensu_go
     description: packagecloud.io mirrors for Sensu Go
     baseurl: "{{ sensu_go_final_repos[ansible_pkg_mgr]['rpm'] }}"
     gpgcheck: "{{ sensu_go_final_repos[ansible_pkg_mgr]['gpgcheck'] }}"
@@ -29,8 +29,8 @@
 
 - name: Configure Sensu Go yum source repos
   yum_repository:
-    file: sensu_prerelease
-    name: sensu_prerelease-source
+    file: sensu_go
+    name: sensu_go-source
     description: packagecloud.io mirrors for Sensu Go Source RPMS
     baseurl: "{{ sensu_go_final_repos[ansible_pkg_mgr]['rpm-src'] }}"
     gpgkey: "{{ sensu_go_final_repos[ansible_pkg_mgr]['gpgkey'] }}"
@@ -48,5 +48,5 @@
     warn: false
   when: sensu_go_import_key.changed
   with_items:
-    - sensu_prerelease
-    - sensu_prerelease-source
+    - sensu_go
+    - sensu_go-source

--- a/tasks/repo/dnf.yml
+++ b/tasks/repo/dnf.yml
@@ -41,8 +41,8 @@
   when: sensu_go_final_repos[ansible_pkg_mgr]['rpm-src'] is defined
 
 - name: Cleanup - Remove old Sensu prerelease repos
-  yum_repository:
-    name: sensu_prerelease
+  file:
+    path: /etc/yum.repos.d/sensu_prerelease
     state: absent
   notify: yum-clean-metadata
 

--- a/tasks/repo/dnf.yml
+++ b/tasks/repo/dnf.yml
@@ -40,6 +40,12 @@
     metadata_expire: "{{ sensu_go_final_repos[ansible_pkg_mgr]['metadata_expire'] }}"
   when: sensu_go_final_repos[ansible_pkg_mgr]['rpm-src'] is defined
 
+- name: Cleanup - Remove old Sensu prerelease repos
+  yum_repository:
+    name: sensu_prerelease
+    state: absent
+  notify: yum-clean-metadata
+
 # HACK: https://github.com/ansible/ansible/issues/20711#issuecomment-306260869
 # Can be removed once we're running w/ a version of Ansible that has https://github.com/ansible/ansible/pull/35989
 - name: Make yum cache to import GPG keys

--- a/tasks/repo/yum.yml
+++ b/tasks/repo/yum.yml
@@ -41,8 +41,8 @@
   when: sensu_go_final_repos[ansible_pkg_mgr]['rpm-src'] is defined
 
 - name: Cleanup - Remove old Sensu prerelease repos
-  yum_repository:
-    file: sensu_prerelease
+  file:
+    path: /etc/yum.repos.d/sensu_prerelease
     state: absent
   notify: yum-clean-metadata
 

--- a/tasks/repo/yum.yml
+++ b/tasks/repo/yum.yml
@@ -16,8 +16,8 @@
 
 - name: Configure Sensu Go yum repos
   yum_repository:
-    file: sensu_prerelease
-    name: sensu_prerelease
+    file: sensu_go
+    name: sensu_go
     description: packagecloud.io mirrors for Sensu Go
     baseurl: "{{ sensu_go_final_repos[ansible_pkg_mgr]['rpm'] }}"
     gpgcheck: "{{ sensu_go_final_repos[ansible_pkg_mgr]['gpgcheck'] }}"
@@ -29,8 +29,8 @@
 
 - name: Configure Sensu Go yum source repos
   yum_repository:
-    file: sensu_prerelease
-    name: sensu_prerelease-source
+    file: sensu_go
+    name: sensu_go-source
     description: packagecloud.io mirrors for Sensu Go Source RPMS
     baseurl: "{{ sensu_go_final_repos[ansible_pkg_mgr]['rpm-src'] }}"
     gpgkey: "{{ sensu_go_final_repos[ansible_pkg_mgr]['gpgkey'] }}"
@@ -48,5 +48,5 @@
     warn: false
   when: sensu_go_import_key.changed
   with_items:
-    - sensu_prerelease
-    - sensu_prerelease-source
+    - sensu_go
+    - sensu_go-source

--- a/tasks/repo/yum.yml
+++ b/tasks/repo/yum.yml
@@ -40,6 +40,12 @@
     metadata_expire: "{{ sensu_go_final_repos[ansible_pkg_mgr]['metadata_expire'] }}"
   when: sensu_go_final_repos[ansible_pkg_mgr]['rpm-src'] is defined
 
+- name: Cleanup - Remove old Sensu prerelease repos
+  yum_repository:
+    file: sensu_prerelease
+    state: absent
+  notify: yum-clean-metadata
+
 # HACK: https://github.com/ansible/ansible/issues/20711#issuecomment-306260869
 # Can be removed once we're running w/ a version of Ansible that has https://github.com/ansible/ansible/pull/35989
 - name: Make yum cache to import GPG keys


### PR DESCRIPTION
Noticed this while looking into another issue I'm having, these names are held over from the Alpha release. I've renamed `sensu_prerelease` to `sensu_go` for consistency. 

Signed-off-by: Jared Ledvina <jared@techsmix.net>