### PR TITLE
Feature: Cleanup various bits

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -695,7 +695,6 @@
                 "sha256:25a1bc1d148c9a640211872b4ff859878d422bccb59c9965e04eed468a0aa180",
                 "sha256:964cedd2b27c492fbf0b7f58b3284a09cf7f99b0f715941fb24a439b3af1bd1a"
             ],
-            "index": "pypi",
             "version": "==0.11.0"
         },
         "poyo": {

--- a/library/sensu_go_check.py
+++ b/library/sensu_go_check.py
@@ -12,7 +12,7 @@ module: sensu_go_check
 
 short_description: Configure Sensu Go checks
 
-version_added: "2.6"
+version_added: "2.7"
 
 description:
     - "Configure and manage Sensu Go checks leveraging sensuctl"
@@ -138,7 +138,7 @@ def run_module():
     sensuctl = Sensuctl(module)
     # Fetch the existing checks so we know what we're working with
     checks = sensuctl.checks_list(module)
-    check_names = [check['name'] for check in checks]
+    check_names = [check['metadata']['name'] for check in checks]
 
     if module.params['state'] == 'list':
         result['checks'] = checks

--- a/molecule/shared/verify.yml
+++ b/molecule/shared/verify.yml
@@ -75,7 +75,7 @@
       register: test_files
 
     - name: Execute Inspec tests
-      command: "{{ inspec_bin }} exec {{ item }} --no-color --reporter progress"
+      command: "{{ inspec_bin }} exec --chef-license accept {{ item }} --no-color --reporter progress"
       register: test_results
       with_items: "{{ test_files.stdout_lines }}"
       ignore_errors: true

--- a/molecule/shared/verify.yml
+++ b/molecule/shared/verify.yml
@@ -8,20 +8,20 @@
     inspec_test_directory: "/tmp/molecule/inspec"
     inspec_downloads:
       el6:
-        url: https://packages.chef.io/files/stable/inspec/3.7.1/el/6/inspec-3.7.1-1.el6.x86_64.rpm
-        sha256: b976fdbf8ce8374a56a7b0a28912a2217124cc3b6b35912bcbf7f4e4a26d1aea
+        url: https://packages.chef.io/files/stable/inspec/4.3.2/el/6/inspec-4.3.2-1.el6.x86_64.rpm
+        sha256: 7f7a4df4c0d956f38b541552c8ab2e832b2437b69b0337a67bb24fcbb807bcbe
       el7:
-        url: https://packages.chef.io/files/stable/inspec/3.7.1/el/7/inspec-3.7.1-1.el7.x86_64.rpm
-        sha256: 2f31bebb15e1fc9fc5134719dfa623661bcf3b0c7bf77c6f85b9779aabd38896
+        url: https://packages.chef.io/files/stable/inspec/4.3.2/el/7/inspec-4.3.2-1.el7.x86_64.rpm
+        sha256: 37151ff63cdbc8522f5ecd6a7d9c8bf7ca8fc68b9aad7000a40c1c9d8ba5c9b2
       ubuntu1404:
-        url: https://packages.chef.io/files/stable/inspec/3.7.1/ubuntu/14.04/inspec_3.7.1-1_amd64.deb
-        sha256: 1c9ccb80ba39484115d4c1d7e2b1258615e9c56079f86963dee9fb2120b94dc3
+        url: https://packages.chef.io/files/stable/inspec/4.3.2/ubuntu/14.04/inspec_4.3.2-1_amd64.deb
+        sha256: 343ec7b04e55aa9cb654c2925c9d40f98980d0ea376552c81582e86c7073ea8a
       ubuntu1604:
-        url: https://packages.chef.io/files/stable/inspec/3.7.1/ubuntu/16.04/inspec_3.7.1-1_amd64.deb
-        sha256: 1c9ccb80ba39484115d4c1d7e2b1258615e9c56079f86963dee9fb2120b94dc3
+        url: https://packages.chef.io/files/stable/inspec/4.3.2/ubuntu/16.04/inspec_4.3.2-1_amd64.deb
+        sha256: 343ec7b04e55aa9cb654c2925c9d40f98980d0ea376552c81582e86c7073ea8a
       ubuntu1804:
-        url: https://packages.chef.io/files/stable/inspec/3.7.1/ubuntu/18.04/inspec_3.7.1-1_amd64.deb
-        sha256: 1c9ccb80ba39484115d4c1d7e2b1258615e9c56079f86963dee9fb2120b94dc3
+        url: https://packages.chef.io/files/stable/inspec/4.3.2/ubuntu/18.04/inspec_4.3.2-1_amd64.deb
+        sha256: 343ec7b04e55aa9cb654c2925c9d40f98980d0ea376552c81582e86c7073ea8a
     inspec_package_deps:
       - lsof
       - net-tools

--- a/tasks/repo/sensu_go/apt.yml
+++ b/tasks/repo/sensu_go/apt.yml
@@ -8,6 +8,12 @@
     url: "{{ sensu_go_final_repos[ansible_pkg_mgr]['key_url'] }}"
     id: "{{ sensu_go_final_repos[ansible_pkg_mgr]['key_id'] }}"
 
+- name: Cleanup - Remove old sensu_prerelease repo
+  file:
+    path: /etc/apt/sources.list.ld/sensu_prerelease.list
+    state: absent
+  notify: update apt cache
+
 - name: Configure Sensu Go apt repos
   apt_repository:
     filename: sensu_go
@@ -22,10 +28,4 @@
     repo: "{{ sensu_go_final_repos[ansible_pkg_mgr]['deb-src'] }}"
     update_cache: false
   when: sensu_go_final_repos[ansible_pkg_mgr]['deb-src'] is defined
-  notify: update apt cache
-
-- name: Cleanup - Remove old sensu_prerelease repo
-  file:
-    path: /etc/apt/sources.list.ld/sensu_prerelease
-    state: absent
   notify: update apt cache


### PR DESCRIPTION
Some minor maintenance for this role, previously, we weren't removing the correct apt sources file, resulting in the old prerelease apt repo's hanging around a bit longer. I also upgraded Inspect to the latest release, updated the pipenv deps, and fixed up `sensu_go_check.py` for the namespace for the check name. 

