### PR TITLE
sensu-go-check: Handle error -1

### DIFF
--- a/library/sensu_go_check.py
+++ b/library/sensu_go_check.py
@@ -327,6 +327,12 @@ class SensuGo(AnsibleModule):
         except Exception as e:
             raise AnsibleModuleError(results={'msg': 'Failed request to {0}'.format(url), 'exception': to_native(e)})
         # TODO: What error codes should we handle here?
+        if info['status'] == -1:
+            self.fail_json(msg='Request to {0} failed with: {1} {2}'.format(
+                url,
+                info['status'],
+                info['msg']
+            ))
         if info['status'] >= 500 or info['status'] == 401:
             self.fail_json(msg='Request to {0} failed with: {1} {2}'.format(
                 url,


### PR DESCRIPTION
Resolves https://github.com/jaredledvina/sensu-go-ansible/issues/97

Allows the module to handle `-1` errors where the underlying connection completely falls over. 

```json
{
  "msg": "Request to https://sensu.techsmix.net:8081/auth failed with: -1 Request failed: <urlopen error [SSL: UNKNOWN_PROTOCOL] unknown protocol (_ssl.c:727)>",
  "failed": true,
  "invocation": {
    "module_args": {
      "stdin": false,
      "protocol": "https",
      "subdue": null,
      "env_vars": null,
      "cron": null,
      "low_flap_threshold": 0,
      "ttl": 0,
      "port": 8081,
      "handlers": [],
      "output_metric_handlers": null,
      "use_proxy": true,
      "namespace": "default",
      "runtime_assets": null,
      "publish": true,
      "state": "absent",
      "output_metric_format": "",
      "metadata": null,
      "url_username": "admin",
      "subscriptions": [],
      "force_basic_auth": true,
      "http_agent": "ansible-httpget",
      "host": "sensu.techsmix.net",
      "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
      "url_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
      "name": "check_failed_units",
      "proxy_requests": null,
      "url": null,
      "interval": 60,
      "round_robin": false,
      "check_hooks": null,
      "command": null,
      "high_flap_threshold": 0,
      "timeout": 0,
      "validate_certs": false,
      "proxy_entity_name": ""
    }
  }
}
```