### PR TITLE
sensu-go-check: Support some common env fallback options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 ---
-group: trusty
+group: xenial
 language: python
 python: "2.7"
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
 install:
   - pip install pipenv
   - pipenv install --two --dev
-  - gem install --no-rdoc --no-ri rubocop
+  - gem install rubocop
 script:
   - pipenv run molecule test --scenario-name $SCENARIO --driver-name docker --destroy always
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
 install:
   - pip install pipenv
   - pipenv install --two --dev
-  - gem install rubocop
+  - gem install --no-rdoc --no-ri rubocop
 script:
   - pipenv run molecule test --scenario-name $SCENARIO --driver-name docker --destroy always
 

--- a/library/sensu_go_check.py
+++ b/library/sensu_go_check.py
@@ -251,7 +251,7 @@ diff:
 
 import json
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.urls import fetch_url, url_argument_spec
 from ansible.module_utils._text import to_native
 
@@ -296,11 +296,35 @@ class SensuGo(AnsibleModule):
 
         args = dict(
             name=dict(type='str', required=True),
-            host=dict(type='str', required=True),
-            port=dict(type='int', default=8080),
-            protocol=dict(type='str', default='http', choices=['http', 'https']),
-            url_username=dict(type='str', default='admin', aliases=['username']),
-            url_password=dict(type='str', default='P@ssword!', no_log=True, aliases=['password']),
+            host=dict(
+                type='str',
+                required=True,
+                fallback=(env_fallback, ['ANSIBLE_SENSU_GO_HOST'])
+            ),
+            port=dict(
+                type='int',
+                default=8080,
+                fallback=(env_fallback, ['ANSIBLE_SENSU_GO_PORT'])
+            ),
+            protocol=dict(
+                type='str',
+                default='http',
+                choices=['http', 'https'],
+                fallback=(env_fallback, ['ANSIBLE_SENSU_GO_PROTOCOL'])
+            ),
+            url_username=dict(
+                type='str',
+                default='admin',
+                aliases=['username'],
+                fallback=(env_fallback, ['ANSIBLE_SENSU_GO_USERNAME'])
+            ),
+            url_password=dict(
+                type='str',
+                default='P@ssword!',
+                no_log=True,
+                aliases=['password'],
+                fallback=(env_fallback, ['ANSIBLE_SENSU_GO_PASSWORD'])
+            ),
             namespace=dict(type='str', default='default'),
         )
         argument_spec.update(args)

--- a/library/sensu_go_check.py
+++ b/library/sensu_go_check.py
@@ -51,6 +51,7 @@ options:
   host:
     description:
       - "The host to query, needs to be running the sensu-backend for API access."
+      - "Required if environmental variable C(ANSIBLE_SENSU_GO_HOST) is not set."
     required: true
     type: str
   http_agent:
@@ -100,11 +101,13 @@ options:
     default: P@ssword!
     description:
       - "Password to use when initially authenticating to the Sensu Go API."
+      - "Can be overriden with the environmental variable C(ANSIBLE_SENSU_GO_PASSWORD)"
     type: str
   port:
     default: 8080
     description:
       - "The port that the Sensu Go API is listening on."
+      - "Can be overriden with the environmental variable C(ANSIBLE_SENSU_GO_PORT)"
     type: int
   protocol:
     choices:
@@ -113,6 +116,7 @@ options:
     default: http
     description:
       - "The protocol to use when accessing the Sensu Go API."
+      - "Can be overriden with the environmental variable C(ANSIBLE_SENSU_GO_PROTOCOL)"
     type: str
   proxy_entity_name:
     description:
@@ -181,6 +185,7 @@ options:
     default: admin
     description:
       - "Username to use when initially authenticating to the Sensu Go API."
+      - "Can be overriden with the environment variable C(ANSIBLE_SENSU_GO_USERNAME)"
     type: str
   validate_certs:
     default: "yes"


### PR DESCRIPTION
This allows folks to configure the following environment variables once and not have to continue to pass through these options each time:
```
ANSIBLE_SENSU_GO_HOST
ANSIBLE_SENSU_GO_PORT
ANSIBLE_SENSU_GO_PROTOCOL
ANSIBLE_SENSU_GO_USERNAME
ANSIBLE_SENSU_GO_PASSWORD
```
