### PR TITLE
sensu-go-check: Only interval or cron if state is present

### DIFF
--- a/library/sensu_go_check.py
+++ b/library/sensu_go_check.py
@@ -493,8 +493,10 @@ def run_module():
         ttl=dict(type='int', default=0),
     )
     module_args.update(sensu_go_check_spec)
-    required_if = [('state', 'present', ['command', 'subscriptions'])]
-    required_one_of = [['interval', 'cron']]
+    required_if = [
+        ('state', 'present', ['command', 'subscriptions']),
+        ('state', 'present', ['interval', 'cron'], True)
+    ]
     mutually_exclusive = [['interval', 'cron']]
 
     result = dict(

--- a/library/sensu_go_check.py
+++ b/library/sensu_go_check.py
@@ -509,7 +509,6 @@ def run_module():
         attributes=sorted(sensu_go_check_spec.keys()),
         supports_check_mode=True,
         required_if=required_if,
-        required_one_of=required_one_of,
         mutually_exclusive=mutually_exclusive
     )
     module.auth()


### PR DESCRIPTION
Figured it out, now we only require `interval` or `cron` if the state is `present`! 