### PR TITLE
sensu-go-check: Improved diffs, cleaner error handling, reduce imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,27 @@ The following Operating Systems are automatically tested:
 - [Ubuntu - 16.04 (Xenial Xerus)](http://releases.ubuntu.com/16.04/)
 - [Ubuntu - 18.04 (Bionic Beaver)](http://releases.ubuntu.com/18.04/)
 
+
+Custom Modules
+--------------
+
+This role includes the following [custom modules](https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#embedding-modules-and-plugins-in-roles):
+- [sensu-go-check](https://github.com/jaredledvina/sensu-go-ansible/blob/master/library/sensu_go_check.py)
+
+At this time, these modules are in [`preview`](https://docs.ansible.com/ansible/2.5/dev_guide/developing_modules_documenting.html#ansible-metadata-block)
+status and may be subject to breaking changes. However, effort will be 
+put in to attempt to not break the them, if possible. Please ensure you 
+review the [CHANGELOG](https://github.com/jaredledvina/sensu-go-ansible/blob/master/CHANGELOG.md) when upgrading.
+
+As described in the [upstream documentation](https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#embedding-modules-and-plugins-in-roles),
+to use the included custom modules, you must first include this role prior to 
+calling the modules. After this role has been included once, they will be 
+availble to subsequent plays/roles.
+
+Currently, documentation for each module is in the `DOCUMENTATION` block in 
+each modules source. Once the modules stabalized, they may be PR'ed upstream
+to the Ansible project.
+
 Caveats
 -------
 

--- a/library/sensu_go_check.py
+++ b/library/sensu_go_check.py
@@ -259,11 +259,6 @@ diff:
          }
 '''
 
-import json
-
-from ansible.module_utils.basic import AnsibleModule, env_fallback
-from ansible.module_utils.urls import fetch_url, url_argument_spec
-from ansible.module_utils._text import to_native
 from ansible.module_utils.sensu_go import SensuGo, recursive_diff
 
 
@@ -351,11 +346,11 @@ def run_module():
                     # return unless set. Currently, that's interval/cron
                     # (depending on which is set in the check), and proxy_requests.
                     check_def.pop(attribute)
-            difference = recursive_diff(response, check_def)
-            if difference:
+            before, after = recursive_diff(response, check_def)
+            if before or after:
                 result['diff'] = {'before': '', 'after': ''}
-                result['diff']['before'] = difference[0]
-                result['diff']['after'] = difference[1]
+                result['diff']['before'] = response
+                result['diff']['after'] = check_def
                 if module.check_mode:
                     result['message'] = 'Would have updated Sensu Go check: {0}'.format(module.params['name'])
                     result['changed'] = True

--- a/library/sensu_go_check.py
+++ b/library/sensu_go_check.py
@@ -15,11 +15,13 @@ ANSIBLE_METADATA = {
 
 DOCUMENTATION = r'''
 ---
-author:
-  - "Jared Ledvina (@jaredledvina)"
+module: sensu_go_check
+short_description: "Manage Sensu Go checks"
 description:
   - "Create/Delete Sensu Go checks"
-module: sensu_go_check
+version_added: "2.9"
+author:
+  - "Jared Ledvina (@jaredledvina)"
 options:
   check_hooks:
     description:
@@ -54,10 +56,6 @@ options:
       - "Required if environmental variable C(ANSIBLE_SENSU_GO_HOST) is not set."
     required: true
     type: str
-  http_agent:
-    default: ansible-httpget
-    description:
-      - "The user agent to configure when accessing the Sensu Go API."
   interval:
     description:
       - "How often the check is executed, in seconds."
@@ -67,6 +65,25 @@ options:
     description:
       - "The flap detection low threshold (% state change) for the check. Sensu uses the same flap detection algorithm as Nagios."
     type: int
+  metadata:
+    type: dict
+    description: Check metadata attributes.
+    suboptions:
+      annotations:
+        type: dict
+        description:
+          - "Non-identifying metadata to include with event data, which can be accessed using event filters."
+          - "You can use annotations to add data that's meaningful to people or external tools interacting with Sensu."
+          - "In contrast to labels, annotations cannot be used in API filtering or sensuctl filtering and do not impact Sensu's internal performance."
+          - "Map of key-value pairs. Keys and values can be any valid UTF-8 string."
+      labels:
+        type: dict
+        description:
+          - "Custom attributes to include with event data, which can be accessed using event filters."
+          - "In contrast to annotations, you can use labels to create meaningful collections that can be selected with API filtering and sensuctl filtering."
+          - "Overusing labels can impact Sensu's internal performance, so we recommend moving complex, non-identifying metadata to annotations."
+          - "Map of key-value pairs. Keys can contain only letters, numbers, and underscores, but must start with a letter."
+          - "Values can be any valid UTF-8 string."
   name:
     description:
       - "A unique string used to identify the check."
@@ -174,11 +191,6 @@ options:
       - "If an agent stops publishing results for the check, and the TTL expires, an event will be created for the agents entity."
       - "The check ttl must be greater than the check interval, and should accommodate time for the check execution and result processing to complete."
     type: int
-  use_proxy:
-    default: "yes"
-    description:
-      - "Configures Ansible to use or ignore an http_proxy."
-    type: bool
   username:
     aliases:
       - url_username
@@ -187,13 +199,6 @@ options:
       - "Username to use when initially authenticating to the Sensu Go API."
       - "Can be overriden with the environment variable C(ANSIBLE_SENSU_GO_USERNAME)"
     type: str
-  validate_certs:
-    default: "yes"
-    description:
-      - "Whether or not Ansible should validate Sensu Go's certs."
-    type: bool
-short_description: "Manage Sensu Go checks"
-version_added: "2.8"
 '''
 
 EXAMPLES = r'''

--- a/module_utils/sensu_go.py
+++ b/module_utils/sensu_go.py
@@ -13,13 +13,6 @@ from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.urls import fetch_url, url_argument_spec
 from ansible.module_utils._text import to_native
 
-class AnsibleModuleError(Exception):
-    def __init__(self, results):
-        self.results = results
-
-    def __repr__(self):
-        print('AnsibleModuleError(results={0})'.format(self.results))
-
 
 # TODO: Once 2.8.0 is released, bump min support and switch to:
 # from ansible.module_utils.common.dict_transformations import recursive_diff
@@ -44,6 +37,9 @@ def recursive_diff(dict1, dict2):
 
 class SensuGo(AnsibleModule):
     def __init__(self, argument_spec, attributes, resource, **kwargs):
+        # The following is required for testing outside of Ansible
+        self._remote_tmp='foobar'
+        self._keep_remote_files=True
         self.headers = {"Content-Type": "application/json"}
         # List of attributes from the upstream specification
         self.attributes = attributes
@@ -67,17 +63,17 @@ class SensuGo(AnsibleModule):
                 choices=['http', 'https'],
                 fallback=(env_fallback, ['ANSIBLE_SENSU_GO_PROTOCOL'])
             ),
-            username=dict(
+            url_username=dict(
                 type='str',
                 default='admin',
-                aliases=['url_username'],
+                aliases=['username'],
                 fallback=(env_fallback, ['ANSIBLE_SENSU_GO_USERNAME'])
             ),
-            password=dict(
+            url_password=dict(
                 type='str',
                 default='P@ssword!',
                 no_log=True,
-                aliases=['url_password'],
+                aliases=['password'],
                 fallback=(env_fallback, ['ANSIBLE_SENSU_GO_PASSWORD'])
             ),
             namespace=dict(type='str', default='default'),
@@ -104,7 +100,10 @@ class SensuGo(AnsibleModule):
                 headers=self.headers
             )
         except Exception as e:
-            raise AnsibleModuleError(results={'msg': 'Failed request to {0}'.format(url), 'exception': to_native(e)})
+            self.fail_json(
+                msg='Failed request to {0}'.format(url),
+                exception=to_native(e)
+            )
         # TODO: What error codes should we handle here?
         if info['status'] == -1:
             self.fail_json(msg='Request to {0} failed with: {1} {2}'.format(
@@ -120,17 +119,22 @@ class SensuGo(AnsibleModule):
                 status=info['status'],
                 url=url,
                 method=method,
-                data=json.loads(data)
+                data=data
             )
-        response = None
-        if resp:
+        # 404 leave resp as Nonne
+        # 204 has a resp but it's ''
+        if resp and info['status'] != 204:
             response = resp.read()
-            if response:
-                try:
-                    response = json.loads(response)
-                except Exception as e:
-                    raise AnsibleModuleError(results={'msg': 'Failed to parse response as JSON: {0}'.format(response), 'exception': to_native(e)})
-        return response, info
+            try:
+                return json.loads(response), info
+            except Exception as e:
+                self.fail_json(
+                    msg='Failed to parse response as JSON: {0}'.format(info),
+                    response=response,
+                    exception=to_native(e)
+                )
+        else:
+            return resp, info
 
     def auth(self):
         # Force basic auth to get access_token

--- a/module_utils/sensu_go.py
+++ b/module_utils/sensu_go.py
@@ -67,17 +67,17 @@ class SensuGo(AnsibleModule):
                 choices=['http', 'https'],
                 fallback=(env_fallback, ['ANSIBLE_SENSU_GO_PROTOCOL'])
             ),
-            url_username=dict(
+            username=dict(
                 type='str',
                 default='admin',
-                aliases=['username'],
+                aliases=['url_username'],
                 fallback=(env_fallback, ['ANSIBLE_SENSU_GO_USERNAME'])
             ),
-            url_password=dict(
+            password=dict(
                 type='str',
                 default='P@ssword!',
                 no_log=True,
-                aliases=['password'],
+                aliases=['url_password'],
                 fallback=(env_fallback, ['ANSIBLE_SENSU_GO_PASSWORD'])
             ),
             namespace=dict(type='str', default='default'),

--- a/module_utils/sensu_go.py
+++ b/module_utils/sensu_go.py
@@ -37,9 +37,6 @@ def recursive_diff(dict1, dict2):
 
 class SensuGo(AnsibleModule):
     def __init__(self, argument_spec, attributes, resource, **kwargs):
-        # The following is required for testing outside of Ansible
-        self._remote_tmp='foobar'
-        self._keep_remote_files=True
         self.headers = {"Content-Type": "application/json"}
         # List of attributes from the upstream specification
         self.attributes = attributes

--- a/module_utils/sensu_go.py
+++ b/module_utils/sensu_go.py
@@ -198,4 +198,9 @@ class SensuGo(AnsibleModule):
             'namespace': self.params['namespace'],
             'name': self.params['name']
         }
+        if self.params['metadata']:
+            if self.params['metadata']['annotations']:
+                check['metadata']['annotations'] = self.params['metadata']['annotations']
+            if self.params['metadata']['labels']:
+                check['metadata']['labels'] = self.params['metadata']['labels']
         return check


### PR DESCRIPTION
Next iteration on `sensu-go-check`!

Firstly, I added a section to the README indicating how to use it and that it's available (as a preview for now). I cleaned up the module documentation, and made sure to call out metadata as a field. Add a bit more logic around handling different responses for the API. Finally, I once again changed the diffing logic such that Ansible actually outputs the *full* diff from what the server returns and what we generate. Turns out the previous setup didn't do the entire thing, I think this output looks much nicer. 