### PR TITLE
sensu-go-check: Add validate_certs, cross-link docs, and more validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
 install:
   - pip install pipenv
   - pipenv install --two --dev
-  - gem install rubocop
+  - gem install rubocop -v 0.68.1
 script:
   - pipenv run molecule test --scenario-name $SCENARIO --driver-name docker --destroy always
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Change Log
 
+## [Unreleased](https://github.com/jaredledvina/sensu-go-ansible/tree/HEAD)
+
+[Full Changelog](https://github.com/jaredledvina/sensu-go-ansible/compare/1.6.0...HEAD)
+
+**Implemented enhancements:**
+
+- sensu-go-check: Improved diffs, cleaner error handling, reduce imports [\#105](https://github.com/jaredledvina/sensu-go-ansible/pull/105) ([jaredledvina](https://github.com/jaredledvina))
+- sensu-go-check: Break out SensuGo as a generic class for future modules [\#103](https://github.com/jaredledvina/sensu-go-ansible/pull/103) ([jaredledvina](https://github.com/jaredledvina))
+- sensu-go-check: Only interval or cron if state is present [\#102](https://github.com/jaredledvina/sensu-go-ansible/pull/102) ([jaredledvina](https://github.com/jaredledvina))
+- sensu-go-check: Support some common env fallback options [\#101](https://github.com/jaredledvina/sensu-go-ansible/pull/101) ([jaredledvina](https://github.com/jaredledvina))
+- sensu-go-check: Actually fix-up diff output [\#100](https://github.com/jaredledvina/sensu-go-ansible/pull/100) ([jaredledvina](https://github.com/jaredledvina))
+- sensu-go-check: Handle error -1 [\#99](https://github.com/jaredledvina/sensu-go-ansible/pull/99) ([jaredledvina](https://github.com/jaredledvina))
+- sensu-go-check: Clean diffs, cleaner args [\#98](https://github.com/jaredledvina/sensu-go-ansible/pull/98) ([jaredledvina](https://github.com/jaredledvina))
+- sensu-go-check: Polish and improvements [\#94](https://github.com/jaredledvina/sensu-go-ansible/pull/94) ([jaredledvina](https://github.com/jaredledvina))
+- sensu-go-check: Migrate to Sensu Go API [\#93](https://github.com/jaredledvina/sensu-go-ansible/pull/93) ([jaredledvina](https://github.com/jaredledvina))
+- Tests: Update Dockerfile to latest upstream version [\#91](https://github.com/jaredledvina/sensu-go-ansible/pull/91) ([jaredledvina](https://github.com/jaredledvina))
+- Correctly remove old apt repo and upgrade Inspec in tests [\#89](https://github.com/jaredledvina/sensu-go-ansible/pull/89) ([jaredledvina](https://github.com/jaredledvina))
+
+**Fixed bugs:**
+
+- sensu-go-check failed to run [\#97](https://github.com/jaredledvina/sensu-go-ansible/issues/97)
+- check name moved under metadata dictionary [\#21](https://github.com/jaredledvina/sensu-go-ansible/issues/21)
+
+**Closed issues:**
+
+- Can't Add Command Line Arguments Once Check is Configured [\#45](https://github.com/jaredledvina/sensu-go-ansible/issues/45)
+
+**Merged pull requests:**
+
+- Use the overrided config to determine when restart services [\#85](https://github.com/jaredledvina/sensu-go-ansible/pull/85) ([torrentalle](https://github.com/torrentalle))
+
 ## [1.6.0](https://github.com/jaredledvina/sensu-go-ansible/tree/1.6.0) (2019-04-19)
 [Full Changelog](https://github.com/jaredledvina/sensu-go-ansible/compare/1.5.0...1.6.0)
 

--- a/library/sensu_go_check.py
+++ b/library/sensu_go_check.py
@@ -199,6 +199,11 @@ options:
       - "Username to use when initially authenticating to the Sensu Go API."
       - "Can be overriden with the environment variable C(ANSIBLE_SENSU_GO_USERNAME)"
     type: str
+  validate_certs:
+    type: bool
+    default: true
+    description:
+      - "Configures whether or now Ansible to validate the Sensu server SSL/TLS certs"
 '''
 
 EXAMPLES = r'''

--- a/library/sensu_go_check.py
+++ b/library/sensu_go_check.py
@@ -375,7 +375,7 @@ def run_module():
                     # (depending on which is set in the check), and proxy_requests.
                     check_def.pop(attribute)
             if response != check_def:
-                result['diff'] = {'before': '', 'after': ''}
+                result['diff'] = {}
                 result['diff']['before'] = response
                 result['diff']['after'] = check_def
                 if module.check_mode:

--- a/library/sensu_go_check.py
+++ b/library/sensu_go_check.py
@@ -207,7 +207,7 @@ options:
     type: bool
     default: true
     description:
-      - "Configures whether or now Ansible to validate the Sensu server SSL/TLS certs"
+      - "Configures whether or not Ansible to validate the Sensu server SSL/TLS certs"
 '''
 
 EXAMPLES = r'''

--- a/library/sensu_go_check.py
+++ b/library/sensu_go_check.py
@@ -22,6 +22,10 @@ description:
 version_added: "2.9"
 author:
   - "Jared Ledvina (@jaredledvina)"
+seealso:
+  - name: Sensu Check documentation
+    description: Upstream Sensu Check documentation which has more details around configuring checks.
+    link: https://docs.sensu.io/sensu-go/latest/reference/checks/
 options:
   check_hooks:
     description:

--- a/module_utils/sensu_go.py
+++ b/module_utils/sensu_go.py
@@ -74,6 +74,7 @@ class SensuGo(AnsibleModule):
                 fallback=(env_fallback, ['ANSIBLE_SENSU_GO_PASSWORD'])
             ),
             namespace=dict(type='str', default='default'),
+            validate_certs=dict(type='bool', default=True),
         )
         argument_spec.update(args)
         super(SensuGo, self).__init__(argument_spec=argument_spec, **kwargs)

--- a/module_utils/sensu_go.py
+++ b/module_utils/sensu_go.py
@@ -14,27 +14,6 @@ from ansible.module_utils.urls import fetch_url, url_argument_spec
 from ansible.module_utils._text import to_native
 
 
-# TODO: Once 2.8.0 is released, bump min support and switch to:
-# from ansible.module_utils.common.dict_transformations import recursive_diff
-# https://github.com/ansible/ansible/blob/3b08e75eb2336950e0d1a617fa89ff9afb43bc72/lib/ansible/module_utils/common/dict_transformations.py#L126-L141
-def recursive_diff(dict1, dict2):
-    left = dict((k, v) for (k, v) in dict1.items() if k not in dict2)
-    right = dict((k, v) for (k, v) in dict2.items() if k not in dict1)
-    for k in (set(dict1.keys()) & set(dict2.keys())):
-        if isinstance(dict1[k], dict) and isinstance(dict2[k], dict):
-            result = recursive_diff(dict1[k], dict2[k])
-            if result:
-                left[k] = result[0]
-                right[k] = result[1]
-        elif dict1[k] != dict2[k]:
-            left[k] = dict1[k]
-            right[k] = dict2[k]
-    if left or right:
-        return left, right
-    else:
-        return None
-
-
 class SensuGo(AnsibleModule):
     def __init__(self, argument_spec, attributes, resource, **kwargs):
         self.headers = {"Content-Type": "application/json"}

--- a/molecule/shared/modules/sensu_go_check/main.yml
+++ b/molecule/shared/modules/sensu_go_check/main.yml
@@ -1,0 +1,97 @@
+---
+- hosts: localhost
+  gather_facts: false
+  module_defaults:
+    sensu_go_check:
+      host: localhost
+  tasks:
+    - name: Ensure http on https fails
+      sensu_go_check:
+        name: check_test
+        state: present
+        command: /bin/true
+        interval: 120
+        protocol: http
+      register: http_on_https
+      failed_when: http_on_https is not failed
+    - name: Ensure agent port fails
+      sensu_go_check:
+        name: check_test
+        state: present
+        command: /bin/true
+        interval: 120
+        port: 8081
+        validate_certs: False
+      register: agent_port
+      failed_when: agent_port is not failed
+    - name: Ensure unknown host fails
+      sensu_go_check:
+        name: check_test
+        state: present
+        command: /bin/true
+        interval: 120
+        host: what.is.this
+      register: unknown_host
+      failed_when: unknown_host is not failed
+    - name: Ensure bad password fails
+      sensu_go_check:
+        name: check_test
+        state: present
+        command: /bin/true
+        interval: 120
+        password: thisisnottherightpassword
+      register: bad_password
+      failed_when: bad_password is not failed
+    - name: Ensure nonexistant namespace fails
+      sensu_go_check:
+        name: check_test
+        state: present
+        command: /bin/true
+        interval: 120
+        namespace: thisdoesnotexist
+      register: bad_namespace
+      failed_when: bad_namespace is not failed
+    - name: Ensure interval and cron fails
+      sensu_go_check:
+        name: check_test
+        state: present
+        command: /bin/true
+        interval: 120
+        cron: "* * * * * *"
+      register: interval_and_cron
+      failed_when: interval_and_cron is not failed
+    - name: Ensure check_example is configured
+      sensu_go_check:
+        name: check_example
+        command: /bin/true
+        interval: 300
+        subscriptions: all
+    - name: Ensure check_example is already configured
+      sensu_go_check:
+        name: check_example
+        command: /bin/true
+        interval: 300
+        subscriptions: all
+      register: check_example_already_configured
+      failed_when: check_example_already_configured is changed
+    - name: Ensure check_example is changed
+      sensu_go_check:
+        name: check_example
+        command: /bin/true
+        interval: 120
+        timeout: 120
+        metadata:
+          annotations:
+            ansible_managed: "true"
+        ttl: 300
+        subscriptions: all
+    - name: Ensure check_example is absent
+      sensu_go_check:
+        name: check_example
+        state: absent
+    - name: Ensure check_example is already absent
+      sensu_go_check:
+        name: check_example
+        state: absent
+      register: check_example_is_already_absent
+      failed_when: check_example_is_already_absent is changed

--- a/molecule/shared/verify.yml
+++ b/molecule/shared/verify.yml
@@ -90,3 +90,8 @@
         msg: "Inspec failed to validate"
       when: item.rc != 0
       with_items: "{{ test_results.results }}"
+
+    - name: Execute all custom module test plays
+      include_tasks: "{{ item }}"
+      with_fileglob:
+        - "{{ playbook_dir }}/modules/*/main.yml"


### PR DESCRIPTION
* Adding back `validate_certs` for folks using HTTPS but without a proper certificate (although, you should fix that :) )
* Add `seealso` to link to the upstream check docs which cover all of the parameters here in much greater detail. 
* Add initial custom validation for the key/value pairs for `annotations` and `labels`. I still have to validate the regex for the `labels` keys but, this is a start. 
* Simplify the creation of the `diff` dictionary. 