### PR TITLE
sensu_go_check - idempotent cron checks

### DIFF
--- a/library/sensu_go_check.py
+++ b/library/sensu_go_check.py
@@ -280,7 +280,7 @@ def run_module():
         env_vars=dict(type='list', elements='str'),
         handlers=dict(type='list', elements='str', default=[]),
         high_flap_threshold=dict(type='int', default=0),
-        interval=dict(type='int'),
+        interval=dict(type='int', default=0),
         low_flap_threshold=dict(type='int', default=0),
         metadata=dict(
             type='dict',

--- a/module_utils/sensu_go.py
+++ b/module_utils/sensu_go.py
@@ -88,7 +88,7 @@ class SensuGo(AnsibleModule):
                 info['status'],
                 info['msg']
             ))
-        if info['status'] >= 500 or info['status'] == 401:
+        if info['status'] >= 500 or info['status'] in [400, 401, 409]:
             self.fail_json(msg='Request to {0} failed with: {1} {2}'.format(
                 url,
                 info['status'],

--- a/molecule/shared/modules/main.yml
+++ b/molecule/shared/modules/main.yml
@@ -61,7 +61,7 @@
     state: present
     command: /bin/true
     interval: 120
-    cron: "* * * * * *"
+    cron: "* * * * *"
   register: interval_and_cron
   failed_when: interval_and_cron is not failed
 
@@ -82,6 +82,15 @@
     subscriptions: all
   register: check_example_already_configured
   failed_when: check_example_already_configured is changed
+
+- name: Ensure check_cron_example with bad cron syntax fails
+  sensu_go_check:
+    name: check_bad_cron_example
+    host: localhost
+    command: /bin/true
+    cron: "* * * * * * * * * *"
+  register: bad_check_cron_example
+  failed_when: bad_check_cron_example is not failed
 
 - name: Ensure check_cron_example is configured
   sensu_go_check:

--- a/molecule/shared/modules/main.yml
+++ b/molecule/shared/modules/main.yml
@@ -88,14 +88,14 @@
     name: check_cron_example
     host: localhost
     command: /bin/true
-    cron: "* * * * * *"
+    cron: "* * * * *"
 
 - name: Ensure check_cron_example is already configured
   sensu_go_check:
     name: check_cron_example
     host: localhost
     command: /bin/true
-    cron: "* * * * * *"
+    cron: "* * * * *"
   register: check_cron_example
   failed_when: check_cron_example is changed
 

--- a/molecule/shared/modules/main.yml
+++ b/molecule/shared/modules/main.yml
@@ -9,6 +9,7 @@
     protocol: https
   register: https_on_http
   failed_when: https_on_http is not failed
+
 - name: Ensure agent port fails
   sensu_go_check:
     name: check_test
@@ -20,6 +21,7 @@
     validate_certs: False
   register: agent_port
   failed_when: agent_port is not failed
+
 - name: Ensure unknown host fails
   sensu_go_check:
     name: check_test
@@ -29,6 +31,7 @@
     host: what.is.this
   register: unknown_host
   failed_when: unknown_host is not failed
+
 - name: Ensure bad password fails
   sensu_go_check:
     name: check_test
@@ -39,6 +42,7 @@
     password: thisisnottherightpassword
   register: bad_password
   failed_when: bad_password is not failed
+
 - name: Ensure nonexistant namespace fails
   sensu_go_check:
     name: check_test
@@ -49,6 +53,7 @@
     namespace: thisdoesnotexist
   register: bad_namespace
   failed_when: bad_namespace is not failed
+
 - name: Ensure interval and cron fails
   sensu_go_check:
     name: check_test
@@ -59,6 +64,7 @@
     cron: "* * * * * *"
   register: interval_and_cron
   failed_when: interval_and_cron is not failed
+
 - name: Ensure check_example is configured
   sensu_go_check:
     name: check_example
@@ -66,6 +72,7 @@
     command: /bin/true
     interval: 300
     subscriptions: all
+
 - name: Ensure check_example is already configured
   sensu_go_check:
     name: check_example
@@ -75,6 +82,23 @@
     subscriptions: all
   register: check_example_already_configured
   failed_when: check_example_already_configured is changed
+
+- name: Ensure check_cron_example is configured
+  sensu_go_check:
+    name: check_cron_example
+    host: localhost
+    command: /bin/true
+    cron: "* * * * * *"
+
+- name: Ensure check_cron_example is already configured
+  sensu_go_check:
+    name: check_cron_example
+    host: localhost
+    command: /bin/true
+    cron: "* * * * * *"
+  register: check_cron_example
+  failed_when: check_cron_example is changed
+
 - name: Ensure check_example is changed
   sensu_go_check:
     name: check_example
@@ -87,11 +111,13 @@
         ansible_managed: "true"
     ttl: 300
     subscriptions: all
+
 - name: Ensure check_example is absent
   sensu_go_check:
     name: check_example
     host: localhost
     state: absent
+
 - name: Ensure check_example is already absent
   sensu_go_check:
     name: check_example


### PR DESCRIPTION
To help with https://github.com/jaredledvina/sensu-go-ansible/issues/124, this adds a test that should fail if there's a bug w/ the idempotent nature of `cron` style checks. 

Opening for TravisCI to run, I expect that this will fail and will work to resolve that on this branch as well. 

Signed-off-by: Jared Ledvina <jared@techsmix.net>